### PR TITLE
Feature/attend-time-fix: 종료 시간에 대한 유연화

### DIFF
--- a/src/cogs/Alert.py
+++ b/src/cogs/Alert.py
@@ -189,9 +189,9 @@ class Alert(commands.Cog):
         self.attend_voters.clear()
 
     def format_time(self, delta: timedelta) -> str:
-        hour = delta.days * 24 + delta.seconds // 3600
-        minute = (delta.seconds % 3600) // 60
-        return f'{hour}시간 {minute}분'
+        hours, remainder = divmod(delta.total_seconds(), 3600)
+        minutes = remainder // 60
+        return f'{hours}시간 {minutes}분'
 
 
 async def setup(bot) -> None:

--- a/src/cogs/Alert.py
+++ b/src/cogs/Alert.py
@@ -106,14 +106,14 @@ class Alert(commands.Cog):
 
         if time(19, 31, 0) <= now.time() <= time(23, 59, 59):
             if before.channel is None and after.channel is not None:
-                self.join_time[member] = now
+                self.join_time[member]: datetime = now
                 logging.info(f'{member.display_name} 님이 {now}에 통화방에 참가했습니다')
 
         if before.channel is None and after.channel is not None:
             if member not in self.voice_times:
                 self.voice_times[member] = timedelta(0)
             self.voice_times[member] += now - self.join_time[member]
-            formatted_time = self.voice_times[member].strftime("%H시간 %M분")
+            formatted_time = self.format_time(self.voice_times[member])
             logging.info(f'{member.display_name} 님이 통화방에서 퇴장했습니다. 누적 접속 시간: {formatted_time}')
             await self.attendance_channel.send(f'<@{member.id}> 님의 현재까지 통화방 누적 접속 시간: {formatted_time}')
 
@@ -184,6 +184,11 @@ class Alert(commands.Cog):
         self.voice_times.clear()
         self.two_hours_members.clear()
         self.attend_voters.clear()
+
+    def format_time(self, delta: timedelta) -> str:
+        hour = delta.days * 24 + delta.seconds // 3600
+        minute = (delta.seconds % 3600) // 60
+        return f'{hour}시간 {minute}분'
 
 
 async def setup(bot) -> None:

--- a/src/cogs/Alert.py
+++ b/src/cogs/Alert.py
@@ -116,6 +116,7 @@ class Alert(commands.Cog):
             formatted_time = self.format_time(self.voice_times[member])
             logging.info(f'{member.display_name} 님이 통화방에서 퇴장했습니다. 누적 접속 시간: {formatted_time}')
             await self.attendance_channel.send(f'<@{member.id}> 님의 현재까지 통화방 누적 접속 시간: {formatted_time}')
+            del self.join_time[member]
 
     # 20:30 지각자 알림
     @tasks.loop(time=time(hour=20, minute=30, second=0, tzinfo=KST))

--- a/src/cogs/Alert.py
+++ b/src/cogs/Alert.py
@@ -40,6 +40,7 @@ class Alert(commands.Cog):
 
         self.attend_voters = []
 
+        self.join_time = {}
         self.voice_times = {}
         self.two_hours_members = []
 
@@ -105,15 +106,16 @@ class Alert(commands.Cog):
 
         if time(19, 31, 0) <= now.time() <= time(23, 59, 59):
             if before.channel is None and after.channel is not None:
-                self.voice_times[member] = self.voice_times.get(member, timedelta(0)) + (
-                        now - self.voice_times.get(member, now))
+                self.join_time[member] = now
                 logging.info(f'{member.display_name} 님이 {now}에 통화방에 참가했습니다')
 
         if before.channel is None and after.channel is not None:
-            if member in self.voice_times:
-                accumulated_time = self.voice_times[member]
-                logging.info(f'{member.display_name} 님이 통화방에서 퇴장했습니다. 누적 접속 시간: {accumulated_time}')
-                await self.attendance_channel.send(f'<@{member.id}> 님의 현재까지 통화방 누적 접속 시간: {accumulated_time}')
+            if member not in self.voice_times:
+                self.voice_times[member] = timedelta(0)
+            self.voice_times[member] += now - self.join_time[member]
+            formatted_time = self.voice_times[member].strftime("%H시간 %M분")
+            logging.info(f'{member.display_name} 님이 통화방에서 퇴장했습니다. 누적 접속 시간: {formatted_time}')
+            await self.attendance_channel.send(f'<@{member.id}> 님의 현재까지 통화방 누적 접속 시간: {formatted_time}')
 
     # 20:30 지각자 알림
     @tasks.loop(time=time(hour=20, minute=30, second=0, tzinfo=KST))

--- a/src/cogs/Alert.py
+++ b/src/cogs/Alert.py
@@ -93,7 +93,7 @@ class Alert(commands.Cog):
     # 19:30 20시 참가자 30분 전 알림
     @tasks.loop(time=time(hour=19, minute=30, second=0, tzinfo=KST))
     async def alert_attendance(self) -> None:
-        if len(self.attend_voters) == 0:
+        if not self.attend_voters:
             logging.info('attend_voters is empty')
             return
 
@@ -131,8 +131,8 @@ class Alert(commands.Cog):
             not_in_voice = [member for member in self.attend_voters if member not in voice_channel_members]
             logging.info(f'Not in voice channel members: {not_in_voice}')
 
-            mentions = ' '.join([f'<@{member.id}>' for member in not_in_voice])
-            if len(not_in_voice) != 0:
+            if not_in_voice:
+                mentions = ' '.join([f'<@{member.id}>' for member in not_in_voice])
                 await self.attendance_channel.send(f'{mentions} 20시 30분 입니다. 혹시 깜빡하셨나요?')
         except Exception as e:
             logging.error(e)

--- a/src/cogs/Alert.py
+++ b/src/cogs/Alert.py
@@ -157,8 +157,9 @@ class Alert(commands.Cog):
             # 접속 중인 사람은 현재 시간으로 계산하여 누적 시간 갱신
             if member in self.voice_channel.members:
                 if member in self.voice_times:
-                    self.voice_times[member] += (now - self.voice_times[member].last_checked)
-                    self.voice_times[member].last_checked = now
+                    self.voice_times[member] += now - self.join_time[member]
+                else:
+                    self.voice_times[member] = now - self.join_time[member]
 
                 # 누적 시간이 2시간 이상인지 체크
                 if self.voice_times[member] >= timedelta(hours=2):
@@ -181,6 +182,7 @@ class Alert(commands.Cog):
             mentions_not_attended = ' '.join([f'<@{member.id}>' for member in not_attended_members])
             await self.attendance_channel.send(f"투표한 사람 중 2시간을 채우지 못한 사람들: {mentions_not_attended}")
 
+        self.join_time.clear()
         self.voice_times.clear()
         self.two_hours_members.clear()
         self.attend_voters.clear()


### PR DESCRIPTION
- 19:31분부터 접속시간 기록합니다. 10~20분 정도 일찍 접속하시는 분들은 재접속하실 필요 없습니다.
- 통화방 종료 시간을 신경쓰지 않도록 변경했습니다. 24시 이후에 종료하더라도 체크하도록 수정하였고, 종료하지 않더라도 24:30 기준으로 접속 시간을 체크하도록 했습니다
- 이제 누적시간으로 체크합니다. 중간에 통화방을 종료하더라도 접속 시간을 체크해서 종료된 시점의 누적 시간을 출력하도록 했습니다(시간 형식 "12시간 34분")